### PR TITLE
fix customer subscription route

### DIFF
--- a/Stripe.pm
+++ b/Stripe.pm
@@ -505,7 +505,7 @@ I<< with a single billing cycle >>, pass each plan as a separate item:
 sub customers_subscribe {
     my $self        = shift;
     my $id          = shift;
-    return $self->_compose("customers/$id/subscription", @_);
+    return $self->_compose("customers/$id/subscriptions", @_);
 }
 
 


### PR DESCRIPTION
There was a small typo on the subscribers route, which is supposed to be plural. This fix was checked against current Stripe API specs.