### PR TITLE
explicit import of encode_base64()

### DIFF
--- a/Stripe.pm
+++ b/Stripe.pm
@@ -6,7 +6,7 @@ use warnings;
 use JSON;
 use LWP::UserAgent;
 use HTTP::Request::Common qw/DELETE GET POST/;
-use MIME::Base64;
+use MIME::Base64 qw(encode_base64);
 
 our $VERSION         = '0.06';
 


### PR DESCRIPTION
This function was being imported by default from MIME::Base64, but it never hurts to make things explicit.