### PR TITLE
format and unify changelog

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,24 +1,25 @@
 Revision history for Business-Stripe
 
-0.01    2012-03-27
-        First version.
+0.06    2016-11-14
+        Fix documentation errors.
+        Change TABs to SPACES.
 
-0.02    2012-03-28
-        Fix missing README.
-        Update docs.
-
-0.03    2012-04-10
-        Add META.json.
-        Fix 'delete' bug.
-        Update docs.
+0.05    2015-11-16
+        Fix POD documentations.
 
 0.04    2012-10-18
         Update Makefile.PL.
 		Update META.json.
-        
-0.05    2015-11-16
-        Fix POD documentations.
-        
-0.06    2016-11-14
-        Fix documentation errors.
-        Change TABs to SPACES.
+
+0.03    2012-04-10
+        - Add META.json.
+        - Fix 'delete' bug.
+        - Add 'customers_subcribe' and 'customers_unsubscribe'
+        - Update docs.
+
+0.02    2012-03-28
+        - Fix missing README.
+        - Update docs.
+
+0.01    2012-03-27
+        - Initial release.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ like `BusinessStripe.pm`).
 LICENSE AND COPYRIGHT
 ---------------------
 
-Copyright (C) 2016-2019 Aquaron. All Rights Reserved.
+Copyright (C) 2012-2019 Aquaron. All Rights Reserved.
 
 This program and library is free software; 
 you can redistribute it and/or modify it under the same terms as Perl 5 itself.

--- a/Stripe.pm
+++ b/Stripe.pm
@@ -638,45 +638,13 @@ Include the file in your program:
  );
  $stripe->charges_list;
 
-=head1 HISTORY
-
-=over 3
-
-=item 2012-03-27
-
-v0.01 Initial release
-
-=item 2012-03-28
-
-v0.02 Revised documentations, add README so tests won't fail.
-
-=item 2012-04-01
-
-v0.03 Update docs with better examples.
-Added C<customers_subscribe> and C<customers_unsubscribe>.
-
-=item 2012-10-18
-
-v0.04 Add dependencies to META.json and Makefile.PL.
-
-=item 2015-11-16
-
-v0.05 Fix POD errors.
-Removed errneous C<currency> from create tokens example.
-
-=item 2016-11-14
-
-v0.06 Fix documentation, change tabs to spaces instead.
-
-=back
-
 =head1 AUTHOR
 
 Paul Pham (@phamnp)
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2016 Aquaron. All Rights Reserved.
+Copyright (C) 2012-2019 Aquaron. All Rights Reserved.
 
 This program and library is free software;
 you can redistribute it and/or modify it under the same terms as Perl itself.


### PR DESCRIPTION
The Changes file was reversed so the most recent changes appear first,
which conforms to the CPAN::Changes standard.

We also centralized all changelog into the Changes file, so we don't
have to update both there and on the module's POD.

Finally, we've also fixed a regression regarding the copyright year,
which started on 2012 and not on 2016.