### PR TITLE
fix full amount refund on charges_refund()

### DIFF
--- a/Stripe.pm
+++ b/Stripe.pm
@@ -569,9 +569,9 @@ sub _compose {
         $res = $self->{-ua}->request(
             DELETE $url, @headers
         );
-    } elsif (scalar @_ >= 2) {
+    } elsif (scalar @_ > 1 || (@_ == 1 && ref $_[0] eq 'ARRAY')) {
         $res = $self->{-ua}->request(
-            POST $url, @headers, Content => [ @_ ]
+            POST $url, @headers, Content => [ @_ == 1 ? @{$_[0]} : @_ ]
         );
     } else {
         $res = $self->{-ua}->request(

--- a/t/20-charges.t
+++ b/t/20-charges.t
@@ -125,10 +125,7 @@ $stripe = Business::Stripe->new(
         content => '{}',
         request => sub {
             my ($self, $req) = @_;
-            TODO: {
-                local $TODO = "should be a POST like the partial call, but it's a GET";
-                Test::More::is($req->method, 'POST', 'charges_refund() method');
-            };
+            Test::More::is($req->method, 'POST', 'charges_refund() method');
             Test::More::is(
                 $req->uri,
                 'https://api.stripe.com/v1/charges/my_charge_id/refunds',


### PR DESCRIPTION
The charges_refund() helper was making a GET request when it
was meant to make a POST request. This happened due to the way
_compose() behaves. This patch allows _compose() to differentiate
between no params (a GET) and an empty arrayref [] (a POST with
no arguments).